### PR TITLE
feat: Add ECMAScript Date API Compatibility to EtDatetime

### DIFF
--- a/lib/src/example/example.js
+++ b/lib/src/example/example.js
@@ -13,11 +13,11 @@ var __1 = require("..");
 var now = new __1.EtDatetime(); // => 2012-07-28 17:18:31.466
 var nowDate = now.date; // => {year: 2012, month: 7, day: 28}
 var nowTIme = now.time; // => {h: 17, m: 18, s: 31}
-console.log("🚀 ~ nowTIme:", nowTIme, now.toISOString());
+// console.log("🚀 ~ nowTIme:", nowTIme, now.toISOString())
 var covidFirstConfirmed = new __1.EtDatetime(2012, 7, 4);
-console.log("🚀 ~ covidFirstConfirmed:", covidFirstConfirmed);
+// console.log("🚀 ~ covidFirstConfirmed:", covidFirstConfirmed)
 var covidFirstConfirmedEpoch = new __1.EtDatetime(covidFirstConfirmed.moment);
-console.log("🚀 ~ covidFirstConfirmedEpoch:", covidFirstConfirmedEpoch);
+// console.log("🚀 ~ covidFirstConfirmedEpoch:", covidFirstConfirmedEpoch)
 // let covidFirstDeath: EtDatetime = EtDatetime.parse("2012-07-26 23:00:00");
 /// Comparison of two EtDatetime Instances
 // Duration daysWithOutDeath = covidFirstConfirmed.difference(covidFirstDeath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.1",
       "license": "MIT",
       "devDependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
         "@types/jest": "^25.2.3",
         "jest": "^25.5.4",
         "prettier": "^2.0.5",
@@ -1004,6 +1005,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -5835,6 +5848,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true
     },
     "node_modules/jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "homepage": "https://github.com/Nabute/AbushakirJs#readme",
   "devDependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
     "@types/jest": "^25.2.3",
     "jest": "^25.5.4",
     "prettier": "^2.0.5",

--- a/src/Abushakir/datetime.ts
+++ b/src/Abushakir/datetime.ts
@@ -23,6 +23,7 @@
 import Datetime from '../Interfaces/EDT';
 import { constants } from '../utils/constants';
 import Duration from '../utils/duration';
+import { Temporal } from '@js-temporal/polyfill';
 
 class EtDatetime implements Datetime {
   /** Epoch-based timestamp in milliseconds (Unix) */
@@ -428,6 +429,314 @@ class EtDatetime implements Datetime {
   toDate(): Date {
     return new Date(this.moment);
   }
+
+  /**
+ * Returns the day of the week (0–6), where 0 is Sunday and 6 is Saturday.
+ * Equivalent to JavaScript Date.prototype.getDay().
+ */
+  getDay(): number {
+    return this.weekday;
+  }
+
+  /**
+   * Returns the day of the month (1–31) in UTC.
+   * Equivalent to Date.prototype.getUTCDate().
+   */
+  getUTCDate(): number {
+    return new Date(this.moment).getUTCDate();
+  }
+
+  /**
+   * Returns the day of the week in UTC (0–6), where 0 is Sunday.
+   * Equivalent to Date.prototype.getUTCDay().
+   */
+  getUTCDay(): number {
+    return new Date(this.moment).getUTCDay();
+  }
+
+  /**
+   * Returns the full year (e.g. 2024) in UTC.
+   * Equivalent to Date.prototype.getUTCFullYear().
+   */
+  getUTCFullYear(): number {
+    return new Date(this.moment).getUTCFullYear();
+  }
+
+  /**
+   * Returns the month (0–11) in UTC.
+   * Equivalent to Date.prototype.getUTCMonth().
+   */
+  getUTCMonth(): number {
+    return new Date(this.moment).getUTCMonth();
+  }
+
+  /**
+   * Returns the hour (0–23) in UTC.
+   * Equivalent to Date.prototype.getUTCHours().
+   */
+  getUTCHours(): number {
+    return new Date(this.moment).getUTCHours();
+  }
+
+  /**
+   * Returns the minute (0–59) in UTC.
+   * Equivalent to Date.prototype.getUTCMinutes().
+   */
+  getUTCMinutes(): number {
+    return new Date(this.moment).getUTCMinutes();
+  }
+
+  /**
+   * Returns the second (0–59) in UTC.
+   * Equivalent to Date.prototype.getUTCSeconds().
+   */
+  getUTCSeconds(): number {
+    return new Date(this.moment).getUTCSeconds();
+  }
+
+  /**
+   * Returns the milliseconds (0–999) in UTC.
+   * Equivalent to Date.prototype.getUTCMilliseconds().
+   */
+  getUTCMilliseconds(): number {
+    return new Date(this.moment).getUTCMilliseconds();
+  }
+
+  /**
+   * Returns the year minus 1900 (e.g., 124 for 2024).
+   * Deprecated in JavaScript, included here for compatibility.
+   */
+  getYear(): number {
+    return this.getFullYear() - 1900;
+  }
+
+
+  /**
+ * Sets the year (offset from 1900), used for legacy JavaScript compatibility.
+ * Equivalent to Date.prototype.setYear().
+ * @param year A number representing the year minus 1900
+ */
+  setYear(year: number): void {
+    this.setFullYear(year + 1900);
+  }
+
+  /**
+   * Sets the day of the month (1–30 for Ethiopian calendar).
+   * @param day The day of the month to set.
+   */
+  setDate(day: number): void {
+    const { year, month } = this;
+    this._updateFromComponents(year, month, day, this.hour, this.minute, this.second, this.millisecond);
+  }
+
+  /**
+   * Sets the full Ethiopian year.
+   * @param year The full year (e.g. 2016).
+   */
+  setFullYear(year: number): void {
+    this._updateFromComponents(year, this.month, this.day, this.hour, this.minute, this.second, this.millisecond);
+  }
+
+  /**
+   * Sets the Ethiopian month (0-indexed to match JavaScript Date).
+   * @param month Zero-based month index (0 = Meskerem).
+   */
+  setMonth(month: number): void {
+    this._updateFromComponents(this.year, month + 1, this.day, this.hour, this.minute, this.second, this.millisecond);
+  }
+
+  /**
+   * Sets the hour of the day (0–23).
+   * @param hours The hour to set.
+   */
+  setHours(hours: number): void {
+    this._updateFromComponents(this.year, this.month, this.day, hours, this.minute, this.second, this.millisecond);
+  }
+
+  /**
+   * Sets the minute (0–59).
+   * @param minutes The minute to set.
+   */
+  setMinutes(minutes: number): void {
+    this._updateFromComponents(this.year, this.month, this.day, this.hour, minutes, this.second, this.millisecond);
+  }
+
+  /**
+   * Sets the second (0–59).
+   * @param seconds The second to set.
+   */
+  setSeconds(seconds: number): void {
+    this._updateFromComponents(this.year, this.month, this.day, this.hour, this.minute, seconds, this.millisecond);
+  }
+
+  /**
+   * Sets the milliseconds (0–999).
+   * @param ms The milliseconds to set.
+   */
+  setMilliseconds(ms: number): void {
+    this._updateFromComponents(this.year, this.month, this.day, this.hour, this.minute, this.second, ms);
+  }
+
+  /**
+   * Sets the timestamp (in milliseconds since the Unix epoch).
+   * @param timestamp Milliseconds since epoch.
+   */
+  setTime(timestamp: number): void {
+    this.fromMillisecondsSinceEpoch(timestamp);
+  }
+
+  /**
+   * Sets the UTC day of the month.
+   * @param day The UTC day to set.
+   */
+  setUTCDate(day: number): void {
+    const d = new Date(this.moment);
+    d.setUTCDate(day);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC full year.
+   * @param year The UTC year to set.
+   */
+  setUTCFullYear(year: number): void {
+    const d = new Date(this.moment);
+    d.setUTCFullYear(year);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC hour.
+   * @param hours The UTC hour to set.
+   */
+  setUTCHours(hours: number): void {
+    const d = new Date(this.moment);
+    d.setUTCHours(hours);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC minute.
+   * @param minutes The UTC minutes to set.
+   */
+  setUTCMinutes(minutes: number): void {
+    const d = new Date(this.moment);
+    d.setUTCMinutes(minutes);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC second.
+   * @param seconds The UTC seconds to set.
+   */
+  setUTCSeconds(seconds: number): void {
+    const d = new Date(this.moment);
+    d.setUTCSeconds(seconds);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC milliseconds.
+   * @param ms The UTC milliseconds to set.
+   */
+  setUTCMilliseconds(ms: number): void {
+    const d = new Date(this.moment);
+    d.setUTCMilliseconds(ms);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+   * Sets the UTC month (0–11).
+   * @param month The UTC month to set.
+   */
+  setUTCMonth(month: number): void {
+    const d = new Date(this.moment);
+    d.setUTCMonth(month);
+    this.fromMillisecondsSinceEpoch(d.getTime());
+  }
+
+  /**
+ * Updates internal `fixed` and `moment` values from full date-time components.
+ *
+ * @param year Ethiopian year
+ * @param month Ethiopian month (1–13)
+ * @param day Ethiopian day of month (1–30)
+ * @param hour Hour (0–23)
+ * @param minute Minute (0–59)
+ * @param second Second (0–59)
+ * @param millisecond Millisecond (0–999)
+ */
+  private _updateFromComponents(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+    second: number,
+    millisecond: number
+  ): void {
+    this.fixed = this.fixedFromEthiopic(year, month, day);
+    this.moment = this.dateToEpoch(year, month, day, hour, minute, second, millisecond);
+  }
+
+
+  // Formatters
+  /**
+ * Returns a human-readable date string using system locale.
+ * Equivalent to Date.prototype.toDateString().
+ */
+  toDateString(): string {
+    return this.toDate().toDateString();
+  }
+
+  /**
+   * Returns a human-readable time string using system locale.
+   * Equivalent to Date.prototype.toTimeString().
+   */
+  toTimeString(): string {
+    return this.toDate().toTimeString();
+  }
+
+  /**
+   * Returns a UTC date-time string.
+   * Equivalent to Date.prototype.toUTCString().
+   */
+  toUTCString(): string {
+    return this.toDate().toUTCString();
+  }
+
+  /**
+   * Returns a locale-sensitive string representation of the date and time.
+   * Equivalent to Date.prototype.toLocaleString().
+   */
+  toLocaleString(): string {
+    return this.toDate().toLocaleString();
+  }
+
+  /**
+   * Returns a locale-sensitive string of just the date portion.
+   * Equivalent to Date.prototype.toLocaleDateString().
+   */
+  toLocaleDateString(): string {
+    return this.toDate().toLocaleDateString();
+  }
+
+  /**
+   * Returns a locale-sensitive string of just the time portion.
+   * Equivalent to Date.prototype.toLocaleTimeString().
+   */
+  toLocaleTimeString(): string {
+    return this.toDate().toLocaleTimeString();
+  }
+
+  /**
+   * Returns a Temporal.Instant object representing this date-time.
+   * Requires Temporal API (ES2024) or @js-temporal/polyfill.
+   */
+  toTemporalInstant(): Temporal.Instant {
+    return Temporal.Instant.fromEpochMilliseconds(this.moment);
+  }
+
 }
 
 export default EtDatetime;

--- a/tests/Datetime.test.ts
+++ b/tests/Datetime.test.ts
@@ -271,111 +271,6 @@ describe('Testing EtDatetime comparision...', () => {
   });
 });
 
-// describe('Testing Helper Methods `sixDigits`', () => {
-//   it('should return a six-digit string for a positive number', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['sixDigits'](300); // Accessing a private method for testing
-
-//     expect(result).toBe('+0300');
-//   });
-
-//   it('should return a six-digit string for a negative number', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['sixDigits'](-300);
-
-//     expect(result).toBe('-0300');
-//   });
-
-//   it('should throw an error for a number outside the valid range', () => {
-//     const etDatetime = new EtDatetime();
-
-//     expect(() => etDatetime['sixDigits'](1000000)).toThrowError('Year out of scope');
-//   });
-// });
-
-// describe('Testing Helper Methods `fourDigits`', () => {
-//   it('should return a four-digit string for positive numbers', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['fourDigits'](1234);
-//     expect(result).toBe('1234');
-//   });
-
-//   it('should return a four-digit string for negative numbers', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['fourDigits'](-5678);
-//     expect(result).toBe('-5678');
-//   });
-
-//   it('should pad with zeros for numbers less than 1000', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['fourDigits'](78);
-//     expect(result).toBe('0078');
-//   });
-
-//   it('should return the input for zero', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['fourDigits'](0);
-//     expect(result).toBe('0000');
-//   });
-// });
-
-// describe('Testing Helper Methods `threeDigits`', () => {
-//   it('should return a string with three digits for numbers greater than or equal to 100', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['threeDigits'](150);
-//     expect(result).toBe('150');
-//   });
-
-//   it('should return a string with two digits and a leading zero for numbers between 10 and 99', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['threeDigits'](42);
-//     expect(result).toBe('042');
-//   });
-
-//   it('should return a string with three digits and leading zeros for numbers between 0 and 9', () => {
-//     const etDatetime = new EtDatetime();
-//     const result = etDatetime['threeDigits'](7);
-//     expect(result).toBe('007');
-//   });
-// });
-
-// describe('Testing Helper Methods `toNumber`', () => {
-//   it('should convert undefined to NaN', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(etDatetime["toNumber"](undefined)).toBeNaN();
-//   });
-
-//   it('should convert null to 0', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(etDatetime["toNumber"](null)).toBe(0);
-//   });
-
-//   it('should convert true to 1', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(etDatetime["toNumber"](true)).toBe(1);
-//   });
-
-//   it('should convert false to 0', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(etDatetime["toNumber"](false)).toBe(0);
-//   });
-
-//   it('should convert numeric strings to numbers', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(etDatetime["toNumber"]('42')).toBe(42);
-//   });
-
-//   it('should throw an error for symbol input', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(() => etDatetime["toNumber"](Symbol())).toThrowError('TYPE ERROR: Unexpected operand type.');
-//   });
-
-//   it('should throw an error for object input', () => {
-//     const etDatetime = new EtDatetime();
-//     expect(() => etDatetime["toNumber"]({})).toThrowError('TYPE ERROR: Unexpected operand type.');
-//   });
-// });
-
 describe('Testing Getters', () => {
   let etDatetime: EtDatetime;
 
@@ -480,7 +375,6 @@ describe('EtDatetime get methods', () => {
   });
 });
 
-
 describe('Symbol.toPrimitive compliance', () => {
   const et = new EtDatetime(2015, 1, 1);
 
@@ -497,11 +391,259 @@ describe('Symbol.toPrimitive compliance', () => {
   });
 });
 
-
 describe('EtDatetime static methods', () => {
   it('EtDatetime.now returns current time instance', () => {
     const now = EtDatetime.now();
     expect(now).toBeInstanceOf(EtDatetime);
     expect(now.getTime()).toBeCloseTo(Date.now(), -2); // ~10ms precision
   });
+});
+
+describe('Formatting: fourDigits()', () => {
+  const testCases = [
+    { year: 5, expected: '0005' },
+    { year: 45, expected: '0045' },
+    { year: 456, expected: '0456' },
+    { year: 1456, expected: '1456' },
+    { year: -5, expected: '-0005' },
+    { year: -45, expected: '-0045' },
+    { year: -456, expected: '-0456' },
+    { year: -1456, expected: '-1456' },
+  ];
+
+  testCases.forEach(({ year, expected }) => {
+    it(`formats year ${year} as ${expected} in toJson().year`, () => {
+      const date = new EtDatetime(year, 1, 1);
+      //@ts-ignore
+      expect((date.toJson())['year']).toBe(expected);
+    });
+  });
+});
+
+describe('Formatting: sixDigits()', () => {
+  it('formats years with six digits and sign prefix', () => {
+    const et1 = new EtDatetime(-9999, 1, 1);
+    const et2 = new EtDatetime(9999, 1, 1);
+    expect(et1.toIso8601String().startsWith('-9999')).toBe(true);
+    expect(et2.toIso8601String().startsWith('9999')).toBe(true);
+  });
+
+  it('throws for year > 9999', () => {
+    const et = new EtDatetime(10000, 1, 1);
+    expect(() => et.toIso8601String()).toThrow('Year out of scope');
+  });
+
+  it('throws for year < -9999', () => {
+    const et = new EtDatetime(-10000, 1, 1);
+    expect(() => et.toIso8601String()).toThrow('Year out of scope');
+  });
+});
+
+describe('EtDatetime ECMAScript API compliance', () => {
+
+  // ------------------------------------------
+  //  Weekday + Legacy Year API
+  // ------------------------------------------
+  describe('getDay() and getYear()', () => {
+    it('getDay() returns weekday index (0–6)', () => {
+      const date = new EtDatetime(2012, 1, 1); // Known Sunday
+      expect(date.getDay()).toBeGreaterThanOrEqual(0);
+      expect(date.getDay()).toBeLessThanOrEqual(6);
+      expect(date.getDay()).toBe(date.weekday);
+    });
+
+    it('getYear returns fullYear - 1900', () => {
+      const et = new EtDatetime(2015, 1, 1);
+      expect(et.getYear()).toBe(et.getFullYear() - 1900);
+    });
+
+    it('setYear sets the full year based on input + 1900', () => {
+      const et = new EtDatetime(2020, 1, 1);
+      et.setYear(120); // Should set full year to 2020 (1900 + 120)
+      expect(et.getFullYear()).toBe(2020);
+    });
+  });
+
+  // ------------------------------------------
+  //  UTC Getters
+  // ------------------------------------------
+  describe('getUTC*() methods', () => {
+    const et = new EtDatetime(2012, 2, 13, 14, 30, 45, 123);
+    const native = et.toDate();
+
+    it('getUTCDate matches JS Date', () => {
+      expect(et.getUTCDate()).toBe(native.getUTCDate());
+    });
+
+    it('getUTCDay matches JS Date', () => {
+      expect(et.getUTCDay()).toBe(native.getUTCDay());
+    });
+
+    it('getUTCFullYear matches JS Date', () => {
+      expect(et.getUTCFullYear()).toBe(native.getUTCFullYear());
+    });
+
+    it('getUTCMonth returns the UTC month (0-indexed)', () => {
+      const et = new EtDatetime(2012, 2, 13, 14, 30, 45, 123);
+      expect(et.getUTCMonth()).toBe(new Date(et.getTime()).getUTCMonth());
+    });    
+
+    it('getUTCHours matches JS Date', () => {
+      expect(et.getUTCHours()).toBe(native.getUTCHours());
+    });
+
+    it('getUTCMinutes matches JS Date', () => {
+      expect(et.getUTCMinutes()).toBe(native.getUTCMinutes());
+    });
+
+    it('getUTCSeconds matches JS Date', () => {
+      expect(et.getUTCSeconds()).toBe(native.getUTCSeconds());
+    });
+
+    it('getUTCMilliseconds matches JS Date', () => {
+      expect(et.getUTCMilliseconds()).toBe(native.getUTCMilliseconds());
+    });
+  });
+
+  // ------------------------------------------
+  //  Setters (Local Time)
+  // ------------------------------------------
+  describe('set*() methods (local time)', () => {
+    it('setDate changes the day of the month', () => {
+      const et = new EtDatetime(2012, 2, 13);
+      et.setDate(5);
+      expect(et.getDate()).toBe(5);
+    });
+
+    it('setFullYear updates the year', () => {
+      const et = new EtDatetime(2010, 2, 13);
+      et.setFullYear(2020);
+      expect(et.getFullYear()).toBe(2020);
+    });
+
+    it('setMonth updates the month (0-indexed)', () => {
+      const et = new EtDatetime(2012, 2, 13);
+      et.setMonth(4); // → month = 5
+      expect(et.getMonth()).toBe(4);
+      expect(et.month).toBe(5);
+    });
+
+    it('setHours, Minutes, Seconds, Milliseconds update correctly', () => {
+      const et = new EtDatetime(2012, 2, 13, 1, 2, 3, 4);
+      et.setHours(5);
+      et.setMinutes(10);
+      et.setSeconds(20);
+      et.setMilliseconds(200);
+
+      expect(et.hour).toBe(5);
+      expect(et.minute).toBe(10);
+      expect(et.second).toBe(20);
+      expect(et.millisecond).toBe(200);
+    });
+
+    it('setTime sets exact timestamp', () => {
+      const now = Date.now();
+      const et = new EtDatetime();
+      et.setTime(now);
+      expect(et.getTime()).toBe(now);
+    });
+  });
+
+  // ------------------------------------------
+  //  Setters (UTC)
+  // ------------------------------------------
+  describe('setUTC*() methods', () => {
+    let et: EtDatetime;
+    let native: Date;
+
+    beforeEach(() => {
+      et = new EtDatetime(2012, 2, 13, 10, 0, 0, 0);
+      native = new Date(et.getTime());
+    });
+
+    it('setUTCFullYear updates UTC year', () => {
+      et.setUTCFullYear(2020);
+      native.setUTCFullYear(2020);
+      expect(et.getUTCFullYear()).toBe(native.getUTCFullYear());
+    });
+
+    it('setUTCMonth updates UTC month', () => {
+      et.setUTCMonth(5);
+      native.setUTCMonth(5);
+      expect(et.getUTCMonth()).toBe(native.getUTCMonth());
+    });
+
+    it('setUTCDate updates UTC day', () => {
+      et.setUTCDate(20);
+      native.setUTCDate(20);
+      expect(et.getUTCDate()).toBe(native.getUTCDate());
+    });
+
+    it('setUTCHours updates UTC hour', () => {
+      et.setUTCHours(22);
+      native.setUTCHours(22);
+      expect(et.getUTCHours()).toBe(native.getUTCHours());
+    });
+
+    it('setUTCMinutes updates UTC minutes', () => {
+      et.setUTCMinutes(45);
+      native.setUTCMinutes(45);
+      expect(et.getUTCMinutes()).toBe(native.getUTCMinutes());
+    });
+
+    it('setUTCSeconds updates UTC seconds', () => {
+      et.setUTCSeconds(59);
+      native.setUTCSeconds(59);
+      expect(et.getUTCSeconds()).toBe(native.getUTCSeconds());
+    });
+
+    it('setUTCMilliseconds updates UTC ms', () => {
+      et.setUTCMilliseconds(789);
+      native.setUTCMilliseconds(789);
+      expect(et.getUTCMilliseconds()).toBe(native.getUTCMilliseconds());
+    });
+  });
+
+  // ------------------------------------------
+  //  Formatters
+  // ------------------------------------------
+  describe('Formatting methods', () => {
+    const et = new EtDatetime(2012, 7, 7, 14, 30, 15, 123);
+
+    it('toDateString matches JS Date string', () => {
+      expect(et.toDateString()).toBe(et.toDate().toDateString());
+    });
+
+    it('toTimeString matches JS Date time', () => {
+      expect(et.toTimeString()).toBe(et.toDate().toTimeString());
+    });
+
+    it('toUTCString matches JS UTC string', () => {
+      expect(et.toUTCString()).toBe(et.toDate().toUTCString());
+    });
+
+    it('toLocaleString matches JS locale string', () => {
+      expect(typeof et.toLocaleString()).toBe('string');
+    });
+
+    it('toLocaleDateString matches JS locale date', () => {
+      expect(et.toLocaleDateString()).toBe(et.toDate().toLocaleDateString());
+    });
+
+    it('toLocaleTimeString matches JS locale time', () => {
+      expect(et.toLocaleTimeString()).toBe(et.toDate().toLocaleTimeString());
+    });
+  });
+
+  // ------------------------------------------
+  //  Temporal API
+  // ------------------------------------------
+  describe('toTemporalInstant()', () => {
+    it('returns Temporal.Instant (requires @js-temporal/polyfill)', () => {
+      const et = new EtDatetime(2012, 7, 7, 14, 30, 15, 123);
+      const instant = et.toTemporalInstant();
+      expect(instant.epochMilliseconds).toBe(et.getTime());
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

This PR enhances the `EtDatetime` class to support a wide range of ECMAScript-compatible `Date` API methods, improving interoperability with existing JavaScript/TypeScript libraries and UI components.

---

## Features Added

### Getters
- `getDay()`
- `getYear()`
- `getUTCDate()`
- `getUTCDay()`
- `getUTCFullYear()`
- `getUTCMonth()`
- `getUTCHours()`
- `getUTCMinutes()`
- `getUTCSeconds()`
- `getUTCMilliseconds()`

### Setters
- `setDate()`
- `setMonth()`
- `setFullYear()`
- `setHours()`
- `setMinutes()`
- `setSeconds()`
- `setMilliseconds()`
- `setTime()`
- `setYear()` (legacy)
- `setUTCDate()`
- `setUTCMonth()`
- `setUTCFullYear()`
- `setUTCHours()`
- `setUTCMinutes()`
- `setUTCSeconds()`
- `setUTCMilliseconds()`

### Formatters
- `toDateString()`
- `toTimeString()`
- `toUTCString()`
- `toLocaleString()`
- `toLocaleDateString()`
- `toLocaleTimeString()`

### ES2024 Temporal Support
- `toTemporalInstant()` (via `@js-temporal/polyfill`)

---

## Tests Added

- New test suite `EtDatetime ECMAScript API compliance`
  - Covers all getters/setters/formatters added
  - Covers edge cases in `fourDigits()` and partially `sixDigits()` formatting

---

## Other Changes

- Added detailed JSDoc annotations for all new and updated methods.

---

## Benefits

- Brings `EtDatetime` closer to a drop-in replacement for native `Date`
- Unlocks compatibility with date-pickers, form inputs, i18n APIs, and libraries expecting native Date APIs
- Improves test coverage and documentation
